### PR TITLE
Correctly escape '\' in TableParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To use it, do `echo "a,b,c\n1,2,3" |] -p FSH_CSV 'myHaskellFunction'`
 Making plugins/external parsers is really easy and involves very little fuss. All you need to do is:
 
 - Make a library project(Using cabal or something else if you want).
-- Build a function named `run` with type signature `run :: [Char] -> String -> IO ()`. The first argument is the function, and the second is command output
+- Build a function named `run` with type signature `run :: String -> String -> IO ()`. The first argument is the function, and the second is command output
 - Publish to hackage
 - Rejoice!
 

--- a/src/ExternalParser.hs
+++ b/src/ExternalParser.hs
@@ -5,7 +5,7 @@ import Language.Haskell.Interpreter as I
 run :: String -> String -> String -> IO ()
 run package functionStr args =
   do
-    externalRunMaybe <- runInterpreter $ setImports ["Prelude",package] >> interpret "run" (as :: ([Char] -> String -> IO ()))
+    externalRunMaybe <- runInterpreter $ setImports ["Prelude",package] >> interpret "run" (as :: (String -> String -> IO ()))
     case externalRunMaybe of 
       (Right externalRun) -> externalRun functionStr args
       (Left err) -> error $ show err 

--- a/src/TableParser.hs
+++ b/src/TableParser.hs
@@ -9,11 +9,11 @@ import Data.List
 
 isChar = (>' ')
 
-charParser :: ReadP [Char]
+charParser :: ReadP String
 charParser = many1 (satisfy isChar)
 
 -- This parses characters till a space is encountered
-getParsed :: ReadS [Char]
+getParsed :: ReadS String
 getParsed = readP_to_S charParser
 
 -- Leading space needs to be removed or else our parser will output []
@@ -21,7 +21,7 @@ removeLeadingSpace (' ':xs) = removeLeadingSpace xs
 removeLeadingSpace str = str
 
 -- Only the last element is of interest, rest are incomplete
-getPair :: [Char] -> ([Char], [Char])
+getPair :: String -> (String, String)
 getPair line =
   parsedPair $ getParsed.removeLeadingSpace $ line
   where
@@ -39,27 +39,27 @@ getPair line =
  - We do this till unparsed is [] ie empty and then we return the list of parsed words.
  -}
 
-getWords' :: [[Char]] -> ([Char], [Char]) -> [[Char]]
+getWords' :: [String] -> (String, String) -> [String]
 getWords' list (parsed,[]) = list++[parsed]
 getWords' list (parsed,unparsed) = return (getPair $ unparsed) >>= getWords' (if length parsed > 0 then (list++[parsed]) else [])
 
-getWords :: [Char] -> [[Char]]
+getWords :: String -> [String]
 getWords line = getWords' [] ([],line)
 
 --- END PARSING
 
 --- TRANSFORMING
 
-mapLines :: [[Char]] -> [[[Char]]]
+mapLines :: [String] -> [[String]]
 mapLines = map getWords
 
-mapQuotes :: [[String]] -> [[Char]]
+mapQuotes :: [[String]] -> [String]
 mapQuotes = map ((\str->","++str).toStringList.encloseWithQuotes)
 
-mapBraces :: [String] -> [Char]
+mapBraces :: [String] -> String
 mapBraces list = "[" ++ (tail (unwords list)) ++ "]"
 
-parse :: [[Char]] -> [Char]
+parse :: [String] -> String
 parse = mapBraces.mapQuotes.mapLines
 
 --- END TRANSFORMING
@@ -75,7 +75,7 @@ addTrailingSpaces :: [String] -> [String]
 addTrailingSpaces strList = [s ++ (replicate (n+k) ' ') | s <- strList, let n = (length (maximum strList) - length s), let k = 6]
 
 
-run :: [Char] -> String -> IO ()
+run :: String -> String -> IO ()
 run functionStr processedArgs =
   do
     splits <- return (lines processedArgs)

--- a/src/TableParser.hs
+++ b/src/TableParser.hs
@@ -22,7 +22,7 @@ removeLeadingSpace str = str
 
 -- Only the last element is of interest, rest are incomplete
 getPair :: [Char] -> ([Char], [Char])
-getPair line = 
+getPair line =
   parsedPair $ getParsed.removeLeadingSpace $ line
   where
     parsedPair list@(x:xs) = last list
@@ -83,15 +83,13 @@ run functionStr processedArgs =
     unparsed <- return (tail splits)
     result <- runInterpreter $ setImports ["Prelude"] >> interpret (functionStr ++ " " ++ parse unparsed) (as :: [[String]])
     case result of
-      (Right res) -> 
+      (Right [])  -> putStrLn header
+      (Right res) ->
         do
-          case res of
-            [] -> putStrLn header
-	    _  -> do
-                    outputMatrix <- return $ transpose $ (if length (getWords header) == length (head res) then getWords header else []) : res
-                    paddedMatrix <- return $ map addTrailingSpaces outputMatrix
-                    output <- return $ map unwords $ transpose paddedMatrix
-                    printList output
-      (Left err)   -> error $ show err
+          outputMatrix <- return $ transpose $ (if length (getWords header) == length (head res) then getWords header else []) : res
+          paddedMatrix <- return $ map addTrailingSpaces outputMatrix
+          output <- return $ map unwords $ transpose paddedMatrix
+          printList output
+      (Left err)  -> error $ show err
 
 --- END EXECUTING


### PR DESCRIPTION
This fixes the "compile error" in scripts like the example (`ps |fsh ...`), however highlights some other issues:
1. The restructure of the table for output (padding with spaces) is wrong. Everything ends up very widely spaced.
2. Table in the bash output aren't really well structured, so a generic TableParser doesn't really play well. i.e. if there are spaces in any of the column values, the column is separated into multiple columns. 
3. The way the TableParser attempts to add/not add the header in the outputMatrix doesn't really work given 2., or if there were any spaces in file names in the `ls -lap`. `ls -lap` output headers will be rejected anyway as they aren't really column headers, so their number doesn't match up to the columns.